### PR TITLE
Correctly set cancelled status

### DIFF
--- a/src/Extension.php
+++ b/src/Extension.php
@@ -94,7 +94,7 @@ class Pronamic_WP_Pay_Extensions_Charitable_Extension {
 
 		switch ( $payment->get_status() ) {
 			case Pronamic_WP_Pay_Statuses::CANCELLED :
-				$donation->update_status( 'charitable-pending' );
+				$donation->update_status( 'charitable-cancelled' );
 
 				$url = home_url();
 


### PR DESCRIPTION
The Charitable equivalent of Pronamic's CANCELLED status is "charitable-cancelled".